### PR TITLE
storage: Handle null role values

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedRole.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRole.java
@@ -1,7 +1,5 @@
 package seedu.address.storage;
 
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedRole.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRole.java
@@ -1,5 +1,7 @@
 package seedu.address.storage;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -42,8 +44,11 @@ class JsonAdaptedRole {
     public Role toModelType() throws IllegalValueException {
         try {
             return Role.valueOf(roleName.toUpperCase());
+        } catch (NullPointerException e) {
+            throw new IllegalValueException(String.format(JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT, "Role"));
         } catch (IllegalArgumentException e) {
-            throw new IllegalValueException("Invalid role: " + roleName);
+            throw new IllegalValueException(Role.MESSAGE_CONSTRAINTS);
         }
     }
+
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -54,6 +54,24 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_personWithMultipleRoles_addSuccessful() throws Exception {
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
+
+        // Create a person with both PATIENT and CAREGIVER roles
+        Person validPersonWithMultipleRoles = new PersonBuilder().withRole("PATIENT", "CAREGIVER").build();
+
+        // Execute the add command
+        CommandResult commandResult = new AddCommand(validPersonWithMultipleRoles).execute(modelStub);
+
+        // Check if the command result is correct
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPersonWithMultipleRoles)),
+                commandResult.getFeedbackToUser());
+
+        // Verify the person was added with the correct roles
+        assertEquals(Arrays.asList(validPersonWithMultipleRoles), modelStub.personsAdded);
+    }
+
+    @Test
     public void equals() {
         Person alice = new PersonBuilder().withName("Alice").build();
         Person bob = new PersonBuilder().withName("Bob").build();

--- a/src/test/java/seedu/address/storage/JsonAdaptedRoleTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedRoleTest.java
@@ -1,0 +1,36 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.Role;
+
+public class JsonAdaptedRoleTest {
+
+    private static final String VALID_ROLE = "PATIENT";
+    private static final String INVALID_ROLE = "NOT_A_ROLE";
+
+    @Test
+    public void toModelType_validRole_returnsRole() throws Exception {
+        JsonAdaptedRole role = new JsonAdaptedRole(VALID_ROLE);
+        assertEquals(Role.PATIENT, role.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidRole_throwsIllegalValueException() {
+        JsonAdaptedRole role = new JsonAdaptedRole(INVALID_ROLE);
+        String expectedMessage = Role.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, role::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullRole_throwsIllegalValueException() {
+        JsonAdaptedRole role = new JsonAdaptedRole((String) null);
+        String expectedMessage = String.format(JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT,
+                Role.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, role::toModelType);
+    }
+}


### PR DESCRIPTION
### Description:
This PR addresses an issue in the `JsonAdaptedRole` class where null values for roles were causing a `NullPointerException` instead of an `IllegalValueException`. By handling null values properly, the PR ensures consistency in error handling across all fields, matching the behavior for other fields in the application.

In addition, a test was added in `AddCommandTest` to verify that persons with multiple roles (e.g., both "PATIENT" and "CAREGIVER") can be successfully added to the address book.

### Main Changes:
- **Null Role Handling:** Updated `JsonAdaptedRole` to throw an `IllegalValueException` for null role values, preventing `NullPointerException`.
- **Test for Multiple Roles:** Added a test in `AddCommandTest` to ensure that adding persons with multiple roles is successful.
- **Refined Error Message:** Improved the error message for invalid role values to match the format used for other fields, ensuring consistency across the app.

### Tests Added:
- **`AddCommandTest`**:
  - `execute_personWithMultipleRoles_addSuccessful`: Verifies that persons with multiple roles can be added successfully to the model.
  
- **`JsonAdaptedRoleTest`**:
  - `toModelType_nullRole_throwsIllegalValueException`: Ensures that a null role value throws an `IllegalValueException`, with the correct message format.

### Why is this PR needed?
This PR improves the robustness of error handling for roles, ensuring that invalid or missing role data is properly caught and reported. The new test for adding persons with multiple roles ensures that the feature works as expected.

Related to #72 
