### PR TITLE
Add method to get formatted appointment details

### DIFF
--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -1,6 +1,8 @@
 package seedu.address.model.appointment;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 import seedu.address.model.appointment.exceptions.InvalidAppointmentException;
 import seedu.address.model.person.Nric;
@@ -127,6 +129,27 @@ public class Appointment {
                 && otherAppointment.getNric().equals(getNric())
                 && otherAppointment.getStartTime().equals(getStartTime())
                 && otherAppointment.getEndTime().equals(getEndTime());
+    }
+
+    public String getAppointmentDetails() {
+        StringBuilder sb = new StringBuilder();
+
+        // Formatter for the full date format like "22 October 2024"
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy");
+
+        String formattedStartDate = startTime.toLocalDate().format(dateFormatter);
+        LocalTime startTimeOfDay = startTime.toLocalTime();
+        String formattedEndDate = endTime.toLocalDate().format(dateFormatter);
+        LocalTime endTimeOfDay = endTime.toLocalTime();
+
+        sb.append("From: " + formattedStartDate + " " + startTimeOfDay + "HRS ");
+        sb.append("To: " + formattedEndDate + " " + endTimeOfDay + "HRS ");
+
+        // Status logic
+        String status = isCompleted ? "Completed" : "Not Completed";
+        sb.append("Status: " + status);
+
+        return sb.toString();
     }
 
 }

--- a/src/test/java/seedu/address/model/appointment/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentTest.java
@@ -215,6 +215,41 @@ public class AppointmentTest {
         // Test that appointments with different end times are not equal
         assertFalse(appointment1.equals(appointment2));
     }
+    @Test
+    public void getAppointmentDetailsTest() {
+        // Prepare the test data
+        Person testPerson = new PersonBuilder().build();
+        LocalDateTime startTime = LocalDateTime.of(2024, 10, 22, 12, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 10, 22, 13, 0);
+
+        // Create an appointment with the completion status as false
+        Appointment appointment = new Appointment("Test Appointment", testPerson.getNric(), startTime, endTime, false);
+
+        // Expected formatted details
+        String expectedDetails = "From: 22 October 2024 12:00HRS To: 22 October 2024 13:00HRS Status: Not Completed";
+
+        // Assert that the details are as expected
+        assertEquals(expectedDetails, appointment.getAppointmentDetails());
+    }
+
+    @Test
+    public void getAppointmentDetailsCompletedTest() {
+        // Prepare the test data
+        Person testPerson = new PersonBuilder().build();
+        LocalDateTime startTime = LocalDateTime.of(2024, 10, 22, 12, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 10, 22, 13, 0);
+
+        // Create an appointment with the completion status as true
+        Appointment appointment = new Appointment("Test Appointment", testPerson.getNric(), startTime, endTime, true);
+
+        // Expected formatted details with completed status
+        String expectedDetails = "From: 22 October 2024 12:00HRS To: 22 October 2024 13:00HRS Status: Completed";
+
+        // Assert that the details are as expected
+        assertEquals(expectedDetails, appointment.getAppointmentDetails());
+    }
+
+
 
 
 


### PR DESCRIPTION
This PR introduces the `getAppointmentDetails` method to the `Appointment` class, providing a formatted string for appointment details. The method formats the start and end times using the pattern `"d MMMM yyyy"` (e.g., `22 October 2024`) and appends the time in `HRS` format. Additionally, it includes the appointment status ("Completed" or "Not Completed") in the output. Related #111 

### Changes:
- **Appointment.java**:
  - Added the `getAppointmentDetails` method to return formatted appointment details including:
    - Start and end times.
    - Status of the appointment.
  
- **AppointmentTest.java**:
  - Added unit tests to verify the correct behavior of the `getAppointmentDetails` method:
    - `getAppointmentDetailsTest`: Validates the output for an incomplete appointment.
    - `getAppointmentDetailsCompletedTest`: Validates the output for a completed appointment.

### Testing:
All relevant unit tests have been added and executed to verify the correctness of the method. The test suite reports successful execution of the new test cases.

### Checklist:
- [x] Implement `getAppointmentDetails` method.
- [x] Add unit tests for incomplete and completed appointments.
- [x] Ensure all tests pass successfully.
