### PR TITLE
Make clear command harder to delete all the data

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,8 +11,10 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
+    public static final String COMMAND_CONFIRM_WORD = "confirm";
+    public static final String MESSAGE_CONFIRMATION_REQUIRED = "Please confirm the clear action"
+            + "by typing: clear confirm";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
-
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -65,7 +65,7 @@ public class AddressBookParser {
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            return new ClearCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.parser;public class ClearCommandParser {
+}

--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -1,2 +1,22 @@
-package seedu.address.logic.parser;public class ClearCommandParser {
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ClearCommand object
+ */
+public class ClearCommandParser implements Parser<ClearCommand> {
+    @Override
+    public ClearCommand parse(String userInput) throws ParseException {
+        // Check if the user provided the "confirm" keyword.
+        boolean isConfirmed = userInput.trim().equalsIgnoreCase("confirm");
+
+        if (!isConfirmed) {
+            throw new ParseException(ClearCommand.MESSAGE_CONFIRMATION_REQUIRED);
+        }
+
+        // Create the ClearCommand with the confirmation status.
+        return new ClearCommand();
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -28,5 +28,4 @@ public class ClearCommandTest {
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
-
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -47,8 +47,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD
+                + " " + ClearCommand.COMMAND_CONFIRM_WORD) instanceof ClearCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.parser;public class ClearCommandParserTest {
+}

--- a/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
@@ -1,2 +1,38 @@
-package seedu.address.logic.parser;public class ClearCommandParserTest {
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.ClearCommand.MESSAGE_CONFIRMATION_REQUIRED;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ClearCommand;
+
+public class ClearCommandParserTest {
+
+    private final ClearCommandParser parser = new ClearCommandParser();
+
+    @Test
+    public void parse_withoutConfirmKeyword_throwsParseException() {
+        assertParseFailure(parser, "", MESSAGE_CONFIRMATION_REQUIRED);
+        assertParseFailure(parser, " ", MESSAGE_CONFIRMATION_REQUIRED);
+        assertParseFailure(parser, "clear", MESSAGE_CONFIRMATION_REQUIRED);
+    }
+
+    @Test
+    public void parse_withConfirmKeyword_returnsClearCommand() throws Exception {
+        // Test with the "confirm" keyword provided
+        assertTrue(parser.parse("confirm") instanceof ClearCommand);
+        assertTrue(parser.parse(" confirm ") instanceof ClearCommand);
+        assertTrue(parser.parse("CONFIRM") instanceof ClearCommand);
+    }
+
+    @Test
+    public void parse_withInvalidInput_throwsParseException() {
+        // Test with invalid input other than "confirm"
+        assertParseFailure(parser, "yes", MESSAGE_CONFIRMATION_REQUIRED);
+        assertParseFailure(parser, "no", MESSAGE_CONFIRMATION_REQUIRED);
+        assertParseFailure(parser, "something else", MESSAGE_CONFIRMATION_REQUIRED);
+    }
 }
+


### PR DESCRIPTION
### Description
This pull request introduces enhancements to the `ClearCommand` to prevent accidental deletion of all entries in the address book. The main improvement is the addition of a required confirmation keyword ("confirm") that ensures the user explicitly confirms the clear action before it is executed.

### Key Changes
- **`ClearCommand`**: Updated to include a mandatory confirmation mechanism. The command now requires the user to type `clear confirm` to proceed with clearing the address book. If the "confirm" keyword is not provided, a `ParseException` is thrown, instructing the user to confirm the action.
- **`ClearCommandParser`**: Updated to handle parsing the `confirm` keyword. If the input does not match "confirm", a `ParseException` is raised, prompting the user with the correct usage.
- **Error Handling**: The `ParseException` message instructs the user to confirm the action by typing `clear confirm`, preventing accidental data loss.
- **Test Cases**: Added test cases in `ClearCommandParserTest` to ensure that:
  - The parser correctly handles input with the "confirm" keyword.
  - A `ParseException` is thrown when the "confirm" keyword is missing or when unexpected input is provided.

### Example Usage
- Correct Usage:
    ```
    > clear confirm
    Address book has been cleared!
    ```
- Incorrect Usage:
    ```
    > clear
    Please confirm the clear action by typing: clear confirm
    ```
    ```
    > clear yes
    Please confirm the clear action by typing: clear confirm
    ```

### Rationale
- This change improves the user experience by preventing accidental clearing of all data.
- It adds a layer of safety by requiring explicit confirmation before executing a potentially destructive command.
- The changes align with best practices for user confirmation in CLI-based applications, ensuring a balance between functionality and user safety.

### Testing
- **Test Coverage**: Added tests for various scenarios in `ClearCommandParserTest`, including valid and invalid input.
- **Verification**: Verified that `ClearCommand` behaves as expected when the "confirm" keyword is provided, and that appropriate error messages are shown when it is missing.
  
### Notes for Reviewers
- Please check the parsing logic in `ClearCommandParser` to ensure that the handling of the "confirm" keyword is robust.
- Review the new test cases to confirm that they cover all edge cases for user input.
- Let me know if you think additional test cases are needed or if any part of the logic could be further simplified.

### Related Issues
- Resolves #100
