### PR TITLE
Remove appointment Command (without Parser)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAppointmentCommand.java
@@ -73,7 +73,7 @@ public class DeleteAppointmentCommand extends Command {
         }
 
         model.removeAppointment(appointment, person);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, startDateTime));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, appointment));
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAppointmentCommand.java
@@ -1,0 +1,64 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+
+public class DeleteAppointmentCommand extends Command {
+
+    public static final String COMMAND_WORD = "deleteapp";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes an appointment from the person identified "
+            + "By the patient's NRIC number"
+            + "\nParameters: "
+            + PREFIX_NRIC + "PATIENT_NRIC\n"
+            + PREFIX_DATE + "DATE (DD/MM/YYYY) \n"
+            + PREFIX_START_TIME + "START_TIME (HH:MM) \n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NRIC + "S1234567A "
+            + PREFIX_DATE + "01/01/2025 "
+            + PREFIX_START_TIME + "10:00";
+    public static final String MESSAGE_SUCCESS = "Deleted appointment: %1$s";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "Incorrect NRIC. Person not found";
+    public static final String MESSAGE_INVALID_DATE = "Invalid date. Please use the DD/MM/YYYY format";
+    public static final String MESSAGE_INVALID_TIME = "Invalid time. Please use the HH:MM format";
+    public static final String MESSAGE_NO_APPOINTMENT = "This appointment does not exist in CareLink";
+    private final Nric patientNric;
+    private final LocalDateTime startDateTime;
+    
+    public DeleteAppointmentCommand(Nric patientNric, LocalDate date, LocalTime startTime) {
+        requireAllNonNull(patientNric, date, startTime);
+        this.patientNric = patientNric;
+        this.startDateTime = LocalDateTime.of(date, startTime);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+
+        Person person = model.getPerson(patientNric);
+
+        if (person == null) {
+            throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
+        }
+        
+        Appointment appointment = model.getAppointmentForPersonAndTime(person, startDateTime);
+
+        if (appointment == null) {
+            throw new CommandException(MESSAGE_NO_APPOINTMENT);
+        }
+        
+        model.removeAppointment(appointment, person);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, startDateTime));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAppointmentCommand.java
@@ -15,6 +15,9 @@ import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 
+/**
+ * Deletes an appointment from the person identified by the patient's NRIC number
+ */
 public class DeleteAppointmentCommand extends Command {
 
     public static final String COMMAND_WORD = "deleteapp";
@@ -35,13 +38,25 @@ public class DeleteAppointmentCommand extends Command {
     public static final String MESSAGE_NO_APPOINTMENT = "This appointment does not exist in CareLink";
     private final Nric patientNric;
     private final LocalDateTime startDateTime;
-    
+
+    /**
+     * Constructs a DeleteAppointmentCommand object
+     * @param patientNric
+     * @param date
+     * @param startTime
+     */
     public DeleteAppointmentCommand(Nric patientNric, LocalDate date, LocalTime startTime) {
         requireAllNonNull(patientNric, date, startTime);
         this.patientNric = patientNric;
         this.startDateTime = LocalDateTime.of(date, startTime);
     }
 
+    /**
+     * Executes the command to delete an appointment for the person with the given NRIC.
+     * @param model the model to execute the command on
+     * @return the command result
+     * @throws CommandException if the person is not found or the appointment does not exist
+     */
     @Override
     public CommandResult execute(Model model) throws CommandException {
 
@@ -50,13 +65,13 @@ public class DeleteAppointmentCommand extends Command {
         if (person == null) {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
         }
-        
+
         Appointment appointment = model.getAppointmentForPersonAndTime(person, startDateTime);
 
         if (appointment == null) {
             throw new CommandException(MESSAGE_NO_APPOINTMENT);
         }
-        
+
         model.removeAppointment(appointment, person);
         return new CommandResult(String.format(MESSAGE_SUCCESS, startDateTime));
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -105,4 +106,6 @@ public interface Model {
     List<Appointment> getAllAppointments();
 
     List<Appointment> getAppointmentsForPerson(Person person);
+
+    Appointment getAppointmentForPersonAndTime(Person person, LocalDateTime startTime);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -196,6 +197,17 @@ public class ModelManager implements Model {
         temp.sort(Comparator.comparing(Appointment::getStartTime));
         return temp;
     }
+
+    public Appointment getAppointmentForPersonAndTime(Person person, LocalDateTime startTime) {
+        List<Appointment> temp = this.getAppointmentsForPerson(person);
+        for (Appointment appointment : temp) {
+            if (appointment.getStartTime().equals(startTime)) {
+                return appointment;
+            }
+        }
+        return null;
+    }
+
 
     //=========== Filtered Person List Accessors =============================================================
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -224,8 +225,10 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-
-
+        @Override
+        public Appointment getAppointmentForPersonAndTime(Person person, LocalDateTime startTime) {
+            throw new AssertionError("This method should not be called.");
+        }
 
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteAppointmentCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 
 import java.time.LocalDate;
@@ -44,4 +45,16 @@ public class DeleteAppointmentCommandTest {
 
         assertCommandSuccess(deleteAppointmentCommand, modelStub, expectedMessage, expectedModelStub);
     }
+
+    @Test
+    public void execute_invalidNric() {
+        Model modelStub = new ModelManager();
+
+        DeleteAppointmentCommand deleteAppointmentCommand = new DeleteAppointmentCommand(VALID_NRIC, VALID_DATE,
+            VALID_START_TIME);
+        String expectedMessage = String.format(DeleteAppointmentCommand.MESSAGE_PERSON_NOT_FOUND, VALID_NRIC);
+
+        assertCommandFailure(deleteAppointmentCommand, modelStub, expectedMessage);
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteAppointmentCommandTest.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+public class DeleteAppointmentCommandTest {
+
+    private static final Nric VALID_NRIC = new PersonBuilder().build().getNric();
+    private static final LocalDate VALID_DATE = LocalDate.of(2025, 10, 22);
+    private static final LocalTime VALID_START_TIME = LocalTime.of(10, 0);
+    private static final LocalTime VALID_END_TIME = LocalTime.of(11, 0);
+
+    @Test
+    public void execute_successfulDeletion() {
+
+        Model modelStub = new ModelManager();
+        Person testPerson = new PersonBuilder().build();
+        modelStub.addPerson(testPerson);
+        Appointment validAppointment = new Appointment(testPerson.getName().toString(), testPerson.getNric(),
+                                LocalDateTime.of(VALID_DATE, VALID_START_TIME),
+                                LocalDateTime.of(VALID_DATE, VALID_END_TIME));
+
+        modelStub.addAppointment(validAppointment, testPerson);
+        DeleteAppointmentCommand deleteAppointmentCommand = new DeleteAppointmentCommand(VALID_NRIC, VALID_DATE,
+            VALID_START_TIME);
+        String expectedMessage = String.format(DeleteAppointmentCommand.MESSAGE_SUCCESS, validAppointment);
+        Model expectedModelStub = new ModelManager();
+        Person expectedTestPerson = new PersonBuilder().build();
+        expectedModelStub.addPerson(expectedTestPerson);
+        expectedModelStub.addAppointment(validAppointment, expectedTestPerson);
+        expectedModelStub.removeAppointment(validAppointment, expectedTestPerson);
+
+        assertCommandSuccess(deleteAppointmentCommand, modelStub, expectedMessage, expectedModelStub);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteAppointmentCommandTest.java
@@ -57,4 +57,16 @@ public class DeleteAppointmentCommandTest {
         assertCommandFailure(deleteAppointmentCommand, modelStub, expectedMessage);
     }
 
+    @Test
+    public void execute_invalidAppointment() {
+        Model modelStub = new ModelManager();
+        Person testPerson = new PersonBuilder().build();
+        modelStub.addPerson(testPerson);
+        DeleteAppointmentCommand deleteAppointmentCommand = new DeleteAppointmentCommand(VALID_NRIC, VALID_DATE,
+            VALID_START_TIME);
+        String expectedMessage = String.format(DeleteAppointmentCommand.MESSAGE_NO_APPOINTMENT);
+
+        assertCommandFailure(deleteAppointmentCommand, modelStub, expectedMessage);
+    }
+
 }


### PR DESCRIPTION
**Title:** Implemented Remove Appointment Command

**Description:**

This PR implements the Remove Appointment Command feature, which allows users to delete existing appointments from the system.

**Changes:**

* Added `DeleteAppointmentCommand` class to handle the removal of appointments
* Updated `AppointmentManager` to support removal of appointments
* Added test cases for `DeleteAppointmentCommand` to ensure correct functionality

**Related Issues:** [Insert relevant issue numbers or links]

**Checklist:**

* [x] Implemented Remove Appointment Command feature
* [x] Added test cases to ensure correct functionality
* [x] Verified that feature works as expected

**Notes:**

* This feature is built on top of the existing appointment management system
* The `DeleteAppointmentCommand` class uses the `AppointmentManager` to remove appointments from the system