### PR TITLE
Add parser to remove appointment

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddAppointmentCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteAppointmentCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteLinkCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case AddAppointmentCommand.COMMAND_WORD:
             return new AddAppointmentParser().parse(arguments);
+
+        case DeleteAppointmentCommand.COMMAND_WORD:
+            return new DeleteAppointmentParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/DeleteAppointmentParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteAppointmentParser.java
@@ -13,8 +13,16 @@ import seedu.address.logic.commands.DeleteAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Nric;
 
+/**
+ *  Parses input arguments and creates a new DeleteAppointmentCommand object
+ */
 public class DeleteAppointmentParser implements Parser<DeleteAppointmentCommand> {
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteAppointmentCommand
+     * and returns a DeleteAppointmentCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public DeleteAppointmentCommand parse(String userInput) throws ParseException {
         ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_NRIC,
             PREFIX_DATE, PREFIX_START_TIME);
@@ -29,11 +37,11 @@ public class DeleteAppointmentParser implements Parser<DeleteAppointmentCommand>
         LocalTime startTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_START_TIME).get());
 
         return new DeleteAppointmentCommand(nric, date, startTime);
-        
+
     }
 
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
-    
+
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteAppointmentParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteAppointmentParser.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.DeleteAppointmentCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Nric;
+
+public class DeleteAppointmentParser implements Parser<DeleteAppointmentCommand> {
+
+    public DeleteAppointmentCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_NRIC,
+            PREFIX_DATE, PREFIX_START_TIME);
+
+        if (!arePrefixesPresent(argumentMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteAppointmentCommand.MESSAGE_USAGE));
+        }
+
+        Nric nric = ParserUtil.parseNric(argumentMultimap.getValue(PREFIX_NRIC).get());
+        LocalDate date = ParserUtil.parseDate(argumentMultimap.getValue(PREFIX_DATE).get());
+        LocalTime startTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_START_TIME).get());
+
+        return new DeleteAppointmentCommand(nric, date, startTime);
+        
+    }
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+    
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -9,6 +9,9 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteAppointmentCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteLinkCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -100,6 +104,20 @@ public class AddressBookParserTest {
         DeleteLinkCommand command = (DeleteLinkCommand) parser.parseCommand(
                 PersonUtil.getDeleteLinkCommand(nric1, nric2));
         assertEquals(new DeleteLinkCommand(nric1, nric2), command);
+    }
+
+    @Test
+    public void parseCommand_deleteAppointment() throws Exception {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+        Nric validNric = new PersonBuilder().build().getNric();
+        String validDate = "22/10/2025";
+        String validStartTime = "10:00";
+        DeleteAppointmentCommand command = (DeleteAppointmentCommand) parser.parseCommand(
+                PersonUtil.getDeleteAppointmentCommand(validNric, validDate, validStartTime)
+        );
+        assertEquals(new DeleteAppointmentCommand(validNric, LocalDate.parse(validDate, dateFormatter),
+            LocalTime.parse(validStartTime, timeFormatter)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
@@ -31,7 +31,7 @@ public class DeleteAppointmentCommandParserTest {
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
         DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
 
-        // Create expected AddAppointmentCommand
+        // Create expected DeleteAppointmentCommand
         DeleteAppointmentCommand expectedCommand = new DeleteAppointmentCommand(
             new Nric(VALID_NRIC_AMY),
             LocalDate.parse(VALID_DATE_APPOINTMENT, dateFormatter),

--- a/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
@@ -1,0 +1,82 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC_APPOINTMENT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_APPOINTMENT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_DESC_APPOINTMENT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_APPOINTMENT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_DESC_APPOINTMENT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteAppointmentCommand;
+import seedu.address.model.person.Nric;
+
+public class DeleteAppointmentCommandParserTest {
+
+    private DeleteAppointmentParser parser = new DeleteAppointmentParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        // Create expected AddAppointmentCommand
+        DeleteAppointmentCommand expectedCommand = new DeleteAppointmentCommand(
+            new Nric(VALID_NRIC_AMY),
+            LocalDate.parse(VALID_DATE_APPOINTMENT, dateFormatter),
+            LocalTime.parse(VALID_START_TIME_APPOINTMENT, timeFormatter)
+        );
+
+        // whitespace preamble with valid fields
+        assertParseSuccess(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT
+            + VALID_START_TIME_DESC_APPOINTMENT, expectedCommand);
+    }
+
+    @Test
+    public void parse_optionalFieldsMissing_failure() {
+        // Missing NRIC
+        assertParseFailure(parser, VALID_DATE_DESC_APPOINTMENT + VALID_START_TIME_DESC_APPOINTMENT,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteAppointmentCommand.MESSAGE_USAGE));
+
+        // Missing date
+        assertParseFailure(parser, NRIC_DESC_AMY + VALID_START_TIME_DESC_APPOINTMENT,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteAppointmentCommand.MESSAGE_USAGE));
+
+        // Missing start time
+        assertParseFailure(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteAppointmentCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidNric_failure() {
+        // Invalid NRIC
+        assertParseFailure(parser, INVALID_NRIC_DESC + VALID_DATE_DESC_APPOINTMENT
+            + VALID_START_TIME_DESC_APPOINTMENT, Nric.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidDateFormat_failure() {
+        // Invalid date format
+        assertParseFailure(parser, NRIC_DESC_AMY + INVALID_DATE_DESC_APPOINTMENT + VALID_START_TIME_DESC_APPOINTMENT,
+            DeleteAppointmentCommand.MESSAGE_INVALID_DATE);
+    }
+
+    @Test
+    public void parse_invalidStartTimeFormat_failure() {
+        // Invalid start time format
+        assertParseFailure(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT + INVALID_START_TIME_DESC,
+            DeleteAppointmentCommand.MESSAGE_INVALID_TIME);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -2,17 +2,20 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CAREGIVER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.DeleteAppointmentCommand;
 import seedu.address.logic.commands.DeleteLinkCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.LinkCommand;
@@ -90,5 +93,10 @@ public class PersonUtil {
 
     public static String getLinkDetails(Nric patient, Nric caregiver) {
         return PREFIX_PATIENT + patient.value + " " + PREFIX_CAREGIVER + caregiver.value;
+    }
+
+    public static String getDeleteAppointmentCommand(Nric testperson, String date, String time) {
+        return DeleteAppointmentCommand.COMMAND_WORD + " " + PREFIX_NRIC + testperson.value
+            + " " + PREFIX_DATE + date + " " + PREFIX_START_TIME + time;
     }
 }


### PR DESCRIPTION
**Title:** Implemented DeleteAppointmentParser

**Description:**

This PR implements the `DeleteAppointmentParser` class, which is responsible for parsing user input to delete appointments.

**Changes:**

* Added `DeleteAppointmentParser` class to parse user input for deleting appointments
* Updated `CommandParser` to use `DeleteAppointmentParser` for delete appointment commands
* Added test cases for `DeleteAppointmentParser` to ensure correct parsing of user input

**Related Issues:** [Insert relevant issue numbers or links]

**Checklist:**

* [x] Implemented DeleteAppointmentParser class
* [x] Updated CommandParser to use DeleteAppointmentParser
* [x] Added test cases to ensure correct parsing of user input
* [x] Verified that parser works as expected

**Notes:**

* The parser supports deleting appointments by nric and date and start time of appointment

Closes with #143 
Associated with #111 