### PR TITLE
Change fields to be optional for edit appointment

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditAppointmentCommand.java
@@ -84,11 +84,12 @@ public class EditAppointmentCommand extends Command {
 
         Appointment appointmentToEdit = model.getAppointmentForPersonAndTime(patient,
                 findStartDateTime);
-        Appointment editedAppointment = createEditedAppointment(appointmentToEdit, editAppointmentDescriptor);
 
-        if (!appointmentToEdit.isSameAppointment(editedAppointment) && model.hasAppointment(editedAppointment)) {
+        if (appointmentToEdit == null) {
             throw new CommandException(MESSAGE_NO_APPOINTMENT);
         }
+
+        Appointment editedAppointment = createEditedAppointment(appointmentToEdit, editAppointmentDescriptor);
 
         model.editAppointment(appointmentToEdit, patient, editedAppointment);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/commands/EditAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditAppointmentCommand.java
@@ -50,6 +50,7 @@ public class EditAppointmentCommand extends Command {
     public static final String MESSAGE_NO_APPOINTMENT = "This appointment does not exist in CareLink";
     public static final String MESSAGE_INVALID_START_END_TIME = "Start time must be before end time";
     public static final String MESSAGE_START_TIME_IN_PAST = "Start time must be in the future";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     private final Nric findPatientNric;
     private final LocalDateTime findStartDateTime;
     private final EditAppointmentDescriptor editAppointmentDescriptor;
@@ -98,8 +99,6 @@ public class EditAppointmentCommand extends Command {
         model.editAppointment(appointmentToEdit, patient, editedAppointment);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        // model.deleteAppointment(patient, appointment);
-        // model.addAppointment(patient, appointment);
         return new CommandResult(String.format(MESSAGE_SUCCESS, editedAppointment));
     }
 
@@ -152,7 +151,6 @@ public class EditAppointmentCommand extends Command {
      * corresponding field value of the appointment.
      */
     public static class EditAppointmentDescriptor {
-        private String name;
         private LocalDateTime startTime;
         private LocalDateTime endTime;
 
@@ -164,21 +162,12 @@ public class EditAppointmentCommand extends Command {
          * A defensive copy of {@code tags} is used internally.
          */
         public EditAppointmentDescriptor(EditAppointmentDescriptor toCopy) {
-            setName(toCopy.name);
             setStartTime(toCopy.startTime);
             setEndTime(toCopy.endTime);
         }
 
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, startTime, endTime);
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public Optional<String> getName() {
-            return Optional.ofNullable(name);
+            return CollectionUtil.isAnyNonNull(startTime, endTime);
         }
 
         public void setStartTime(LocalDateTime startDateTime) {
@@ -209,15 +198,13 @@ public class EditAppointmentCommand extends Command {
             }
 
             EditAppointmentDescriptor otherEditPersonDescriptor = (EditAppointmentDescriptor) other;
-            return Objects.equals(name, otherEditPersonDescriptor.name)
-                    && Objects.equals(startTime, otherEditPersonDescriptor.startTime)
+            return Objects.equals(startTime, otherEditPersonDescriptor.startTime)
                     && Objects.equals(endTime, otherEditPersonDescriptor.endTime);
         }
 
         @Override
         public String toString() {
             return new ToStringBuilder(this)
-                    .add("name", name)
                     .add("startTime", startTime)
                     .add("endTime", endTime)
                     .toString();

--- a/src/main/java/seedu/address/logic/parser/EditAppointmentParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditAppointmentParser.java
@@ -56,36 +56,22 @@ public class EditAppointmentParser implements Parser<EditAppointmentCommand> {
         LocalDate originalDate = ParserUtil.parseDate(argumentMultimap.getValue(PREFIX_DATE).get());
         LocalTime originalStartTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_START_TIME).get());
 
-        LocalDate newDate;
-        LocalTime newStartTime;
-        LocalTime newEndTime;
-        Boolean edited = false;
+        EditAppointmentDescriptor editAppointmentDescriptor = new EditAppointmentDescriptor();
         if (argumentMultimap.getValue(PREFIX_NEW_DATE).isPresent()) {
-            newDate = ParserUtil.parseDate(argumentMultimap.getValue(PREFIX_NEW_DATE).get());
-            edited = true;
-        } else {
-            newDate = originalDate;
+            editAppointmentDescriptor.setDate(ParserUtil.parseDate(argumentMultimap.getValue(PREFIX_NEW_DATE).get()));
         }
         if (argumentMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()) {
-            newStartTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_NEW_START_TIME).get());
-            edited = true;
-        } else {
-            newStartTime = originalStartTime;
+            editAppointmentDescriptor
+                    .setStartTime(ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_NEW_START_TIME).get()));
         }
         if (argumentMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
-            newEndTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_NEW_END_TIME).get());
-            edited = true;
-        } else {
-            newEndTime = originalStartTime;
+            editAppointmentDescriptor
+                    .setEndTime(ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_NEW_END_TIME).get()));
         }
-        EditAppointmentDescriptor editAppointmentDescriptor = new EditAppointmentDescriptor();
-
-        editAppointmentDescriptor.setStartTime(LocalDateTime.of(newDate, newStartTime));
-        editAppointmentDescriptor.setEndTime(LocalDateTime.of(newDate, newEndTime));
 
         LocalDateTime originalStartDateTime = LocalDateTime.of(originalDate, originalStartTime);
 
-        if (!edited) {
+        if (!editAppointmentDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditAppointmentCommand.MESSAGE_NOT_EDITED);
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditAppointmentParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditAppointmentParser.java
@@ -40,10 +40,7 @@ public class EditAppointmentParser implements Parser<EditAppointmentCommand> {
 
         if (!arePrefixesPresent(argumentMultimap, PREFIX_NRIC,
                 PREFIX_DATE,
-                PREFIX_START_TIME,
-                PREFIX_NEW_DATE,
-                PREFIX_NEW_START_TIME,
-                PREFIX_NEW_END_TIME)) {
+                PREFIX_START_TIME)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditAppointmentCommand.MESSAGE_USAGE));
         }
@@ -58,16 +55,39 @@ public class EditAppointmentParser implements Parser<EditAppointmentCommand> {
         Nric originalNric = ParserUtil.parseNric(argumentMultimap.getValue(PREFIX_NRIC).get());
         LocalDate originalDate = ParserUtil.parseDate(argumentMultimap.getValue(PREFIX_DATE).get());
         LocalTime originalStartTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_START_TIME).get());
-        LocalDate newDate = ParserUtil.parseDate(argumentMultimap.getValue(PREFIX_NEW_DATE).get());
-        LocalTime newStartTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_NEW_START_TIME).get());
-        LocalTime newEndTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_NEW_END_TIME).get());
 
+        LocalDate newDate;
+        LocalTime newStartTime;
+        LocalTime newEndTime;
+        Boolean edited = false;
+        if (argumentMultimap.getValue(PREFIX_NEW_DATE).isPresent()) {
+            newDate = ParserUtil.parseDate(argumentMultimap.getValue(PREFIX_NEW_DATE).get());
+            edited = true;
+        } else {
+            newDate = originalDate;
+        }
+        if (argumentMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()) {
+            newStartTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_NEW_START_TIME).get());
+            edited = true;
+        } else {
+            newStartTime = originalStartTime;
+        }
+        if (argumentMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
+            newEndTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_NEW_END_TIME).get());
+            edited = true;
+        } else {
+            newEndTime = originalStartTime;
+        }
         EditAppointmentDescriptor editAppointmentDescriptor = new EditAppointmentDescriptor();
 
         editAppointmentDescriptor.setStartTime(LocalDateTime.of(newDate, newStartTime));
         editAppointmentDescriptor.setEndTime(LocalDateTime.of(newDate, newEndTime));
 
         LocalDateTime originalStartDateTime = LocalDateTime.of(originalDate, originalStartTime);
+
+        if (!edited) {
+            throw new ParseException(EditAppointmentCommand.MESSAGE_NOT_EDITED);
+        }
 
         return new EditAppointmentCommand(originalNric, originalStartDateTime, editAppointmentDescriptor);
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -185,12 +185,10 @@ public class CommandTestUtil {
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
 
         DESC_APPOINTMENT_AMY = new EditAppointmentDescriptorBuilder()
-                .withName(VALID_NAME_AMY)
                 .withDate(VALID_DATE_APPOINTMENT_AMY)
                 .withStartTime(VALID_START_TIME_APPOINTMENT_AMY)
                 .withEndTime(VALID_END_TIME_APPOINTMENT_AMY).build();
         DESC_APPOINTMENT_BOB = new EditAppointmentDescriptorBuilder()
-                .withName(VALID_NAME_BOB)
                 .withDate(VALID_DATE_APPOINTMENT_BOB)
                 .withStartTime(VALID_START_TIME_APPOINTMENT_BOB)
                 .withEndTime(VALID_END_TIME_APPOINTMENT_BOB).build();

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -97,6 +97,11 @@ public class CommandTestUtil {
             + VALID_START_TIME_APPOINTMENT_BOB;
     public static final String VALID_END_TIME_APPOINTMENT_DESC_BOB = " " + PREFIX_END_TIME
             + VALID_END_TIME_APPOINTMENT_BOB;
+    public static final String VALID_NEW_DATE_APPOINTMENT_DESC_BOB = " " + PREFIX_NEW_DATE + VALID_DATE_APPOINTMENT_BOB;
+    public static final String VALID_NEW_START_TIME_APPOINTMENT_DESC_BOB = " " + PREFIX_NEW_START_TIME
+            + VALID_START_TIME_APPOINTMENT_BOB;
+    public static final String VALID_NEW_END_TIME_APPOINTMENT_DESC_BOB = " " + PREFIX_NEW_END_TIME
+            + VALID_END_TIME_APPOINTMENT_BOB;
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/commands/EditAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditAppointmentCommandTest.java
@@ -7,12 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_APPOINTMENT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE_TIME_APPOINTMENT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_TIME_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_UNIQUE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_TIME_APPOINTMENT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_TIME_APPOINTMENT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,10 +30,10 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.EditAppointmentDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 public class EditAppointmentCommandTest {
-    private static final Nric VALID_NRIC = new PersonBuilder().build().getNric();
     private static final LocalDate VALID_DATE = LocalDate.of(2025, 10, 22);
     private static final LocalTime VALID_START_TIME = LocalTime.of(10, 0);
     private static final LocalTime VALID_END_TIME = LocalTime.of(11, 0);
@@ -42,12 +45,12 @@ public class EditAppointmentCommandTest {
     }
 
     @Test
-    public void execute_appointmentAcceptedByModel_addSuccessful() throws Exception {
+    public void execute_appointmentAcceptedByModel_editSuccessful() throws Exception {
         Model modelStub = new ModelManager();
         Person testPerson = new PersonBuilder().withNric(VALID_NRIC_BOB).withName(VALID_NAME_BOB).build();
         modelStub.addPerson(testPerson);
 
-        CommandResult commandResult = new AddAppointmentCommand(new Nric(VALID_NRIC_BOB), VALID_DATE,
+        new AddAppointmentCommand(new Nric(VALID_NRIC_BOB), VALID_DATE,
                 VALID_START_TIME, VALID_END_TIME)
                 .execute(modelStub);
 
@@ -61,6 +64,45 @@ public class EditAppointmentCommandTest {
         assertEquals(String.format(EditAppointmentCommand.MESSAGE_SUCCESS, editedAppointment),
                 editCommandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(editedAppointment), modelStub.getAllAppointments());
+    }
+
+    @Test
+    public void execute_noAppointmentFoundByModel_editFailure() throws Exception {
+        Model modelStub = new ModelManager();
+        Person testPerson = new PersonBuilder().withNric(VALID_NRIC_BOB).withName(VALID_NAME_BOB).build();
+        modelStub.addPerson(testPerson);
+
+        new AddAppointmentCommand(new Nric(VALID_NRIC_BOB), VALID_DATE,
+                VALID_START_TIME, VALID_END_TIME)
+                .execute(modelStub);
+
+        EditAppointmentDescriptor editAppointmentDescriptor = new EditAppointmentDescriptorBuilder()
+                .build();
+
+        EditAppointmentCommand editCommand = new EditAppointmentCommand(new Nric(VALID_NRIC_BOB),
+                VALID_START_DATE_TIME_APPOINTMENT_AMY,
+                editAppointmentDescriptor);
+        assertCommandFailure(editCommand, modelStub, EditAppointmentCommand.MESSAGE_NO_APPOINTMENT);
+    }
+
+    @Test
+    public void execute_appointmentStartTimeAfterEndTimeByModel_editFailure() throws Exception {
+        Model modelStub = new ModelManager();
+        Person testPerson = new PersonBuilder().withNric(VALID_NRIC_BOB).withName(VALID_NAME_BOB).build();
+        modelStub.addPerson(testPerson);
+
+        new AddAppointmentCommand(new Nric(VALID_NRIC_BOB), VALID_DATE,
+                VALID_START_TIME, VALID_END_TIME)
+                .execute(modelStub);
+
+        EditAppointmentDescriptor editAppointmentDescriptor = new EditAppointmentDescriptorBuilder()
+                .withStartTime(VALID_START_TIME_APPOINTMENT_AMY).withEndTime(VALID_END_TIME_APPOINTMENT_BOB)
+                .build();
+
+        EditAppointmentCommand editCommand = new EditAppointmentCommand(new Nric(VALID_NRIC_BOB),
+                startDateTime,
+                editAppointmentDescriptor);
+        assertCommandFailure(editCommand, modelStub, EditAppointmentCommand.MESSAGE_INVALID_START_END_TIME);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditAppointmentDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditAppointmentDescriptorTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_APPOINTMENT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_END_TIME_APPOINTMENT_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_APPOINTMENT_BOB;
 
 import org.junit.jupiter.api.Test;
@@ -34,13 +33,8 @@ public class EditAppointmentDescriptorTest {
         // different values -> returns false
         assertFalse(DESC_APPOINTMENT_AMY.equals(DESC_APPOINTMENT_BOB));
 
-        // different name -> returns false
-        EditAppointmentDescriptor editedAmy = new EditAppointmentDescriptorBuilder(DESC_APPOINTMENT_AMY)
-                .withName(VALID_NAME_BOB).build();
-        assertFalse(DESC_APPOINTMENT_AMY.equals(editedAmy));
-
         // different start time -> returns false
-        editedAmy = new EditAppointmentDescriptorBuilder(DESC_APPOINTMENT_AMY)
+        EditAppointmentDescriptor editedAmy = new EditAppointmentDescriptorBuilder(DESC_APPOINTMENT_AMY)
                 .withDate(VALID_DATE_APPOINTMENT_BOB)
                 .withStartTime(VALID_START_TIME_APPOINTMENT_BOB).build();
         assertFalse(DESC_APPOINTMENT_AMY.equals(editedAmy));
@@ -55,8 +49,7 @@ public class EditAppointmentDescriptorTest {
     @Test
     public void toStringMethod() {
         EditAppointmentDescriptor editAppointmentDescriptor = new EditAppointmentDescriptor();
-        String expected = EditAppointmentDescriptor.class.getCanonicalName() + "{name="
-                + editAppointmentDescriptor.getName().orElse(null) + ", startTime="
+        String expected = EditAppointmentDescriptor.class.getCanonicalName() + "{startTime="
                 + editAppointmentDescriptor.getStartTime().orElse(null) + ", endTime="
                 + editAppointmentDescriptor.getEndTime().orElse(null) + "}";
         assertEquals(expected, editAppointmentDescriptor.toString());

--- a/src/test/java/seedu/address/logic/commands/EditAppointmentDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditAppointmentDescriptorTest.java
@@ -49,7 +49,8 @@ public class EditAppointmentDescriptorTest {
     @Test
     public void toStringMethod() {
         EditAppointmentDescriptor editAppointmentDescriptor = new EditAppointmentDescriptor();
-        String expected = EditAppointmentDescriptor.class.getCanonicalName() + "{startTime="
+        String expected = EditAppointmentDescriptor.class.getCanonicalName() + "{date="
+                + editAppointmentDescriptor.getDate().orElse(null) + ", startTime="
                 + editAppointmentDescriptor.getStartTime().orElse(null) + ", endTime="
                 + editAppointmentDescriptor.getEndTime().orElse(null) + "}";
         assertEquals(expected, editAppointmentDescriptor.toString());

--- a/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
@@ -5,15 +5,15 @@ import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.START_TIME_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_APPOINTMENT_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_END_TIME_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_APPOINTMENT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_TIME_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NEW_DATE_APPOINTMENT_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NEW_END_TIME_APPOINTMENT_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NEW_START_TIME_APPOINTMENT_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NEW_DATE_APPOINTMENT_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NEW_END_TIME_APPOINTMENT_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NEW_START_TIME_APPOINTMENT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_TIME_APPOINTMENT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_APPOINTMENT_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -35,13 +35,58 @@ public class EditAppointmentCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         Nric targetNric = new Nric(VALID_NRIC_AMY);
         String userInput = NRIC_DESC_AMY + DATE_DESC_AMY + START_TIME_DESC_AMY
-                + VALID_NEW_DATE_APPOINTMENT_DESC_AMY + VALID_NEW_START_TIME_APPOINTMENT_DESC_AMY
-                + VALID_NEW_END_TIME_APPOINTMENT_DESC_AMY;
+                + VALID_NEW_DATE_APPOINTMENT_DESC_BOB + VALID_NEW_START_TIME_APPOINTMENT_DESC_BOB
+                + VALID_NEW_END_TIME_APPOINTMENT_DESC_BOB;
         System.out.println(userInput);
         EditAppointmentDescriptor descriptor = new EditAppointmentDescriptorBuilder()
-                .withDate(VALID_DATE_APPOINTMENT_AMY)
-                .withStartTime(VALID_START_TIME_APPOINTMENT_AMY)
-                .withEndTime(VALID_END_TIME_APPOINTMENT_AMY)
+                .withDate(VALID_DATE_APPOINTMENT_BOB)
+                .withStartTime(VALID_START_TIME_APPOINTMENT_BOB)
+                .withEndTime(VALID_END_TIME_APPOINTMENT_BOB)
+                .build();
+        EditAppointmentCommand expectedCommand = new EditAppointmentCommand(targetNric,
+                VALID_START_DATE_TIME_APPOINTMENT, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_dateFieldSpecified_success() {
+        Nric targetNric = new Nric(VALID_NRIC_AMY);
+        String userInput = NRIC_DESC_AMY + DATE_DESC_AMY + START_TIME_DESC_AMY
+                + VALID_NEW_DATE_APPOINTMENT_DESC_BOB;
+        System.out.println(userInput);
+        EditAppointmentDescriptor descriptor = new EditAppointmentDescriptorBuilder()
+                .withDate(VALID_DATE_APPOINTMENT_BOB)
+                .build();
+        EditAppointmentCommand expectedCommand = new EditAppointmentCommand(targetNric,
+                VALID_START_DATE_TIME_APPOINTMENT, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_startTimeFieldSpecified_success() {
+        Nric targetNric = new Nric(VALID_NRIC_AMY);
+        String userInput = NRIC_DESC_AMY + DATE_DESC_AMY + START_TIME_DESC_AMY
+                + VALID_NEW_START_TIME_APPOINTMENT_DESC_BOB;
+        System.out.println(userInput);
+        EditAppointmentDescriptor descriptor = new EditAppointmentDescriptorBuilder()
+                .withStartTime(VALID_START_TIME_APPOINTMENT_BOB)
+                .build();
+        EditAppointmentCommand expectedCommand = new EditAppointmentCommand(targetNric,
+                VALID_START_DATE_TIME_APPOINTMENT, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_endTimeFieldSpecified_success() {
+        Nric targetNric = new Nric(VALID_NRIC_AMY);
+        String userInput = NRIC_DESC_AMY + DATE_DESC_AMY + START_TIME_DESC_AMY
+                + VALID_NEW_END_TIME_APPOINTMENT_DESC_BOB;
+        System.out.println(userInput);
+        EditAppointmentDescriptor descriptor = new EditAppointmentDescriptorBuilder()
+                .withEndTime(VALID_END_TIME_APPOINTMENT_BOB)
                 .build();
         EditAppointmentCommand expectedCommand = new EditAppointmentCommand(targetNric,
                 VALID_START_DATE_TIME_APPOINTMENT, descriptor);

--- a/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
@@ -101,6 +101,10 @@ public class EditAppointmentCommandParserTest {
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+
+        // no field changed
+        assertParseFailure(parser, NRIC_DESC_AMY + DATE_DESC_AMY + START_TIME_DESC_AMY,
+                EditAppointmentCommand.MESSAGE_NOT_EDITED);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EditAppointmentDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditAppointmentDescriptorBuilder.java
@@ -32,17 +32,8 @@ public class EditAppointmentDescriptorBuilder {
      */
     public EditAppointmentDescriptorBuilder(Appointment appointment) {
         descriptor = new EditAppointmentDescriptor();
-        descriptor.setName(appointment.getName());
         descriptor.setStartTime(appointment.getStartTime());
         descriptor.setEndTime(appointment.getEndTime());
-    }
-
-    /**
-     * Sets the {@code Name} of the {@code EditAppointmentDescriptor} that we are building.
-     */
-    public EditAppointmentDescriptorBuilder withName(String name) {
-        descriptor.setName(name);
-        return this;
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/EditAppointmentDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditAppointmentDescriptorBuilder.java
@@ -1,7 +1,6 @@
 package seedu.address.testutil;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
@@ -13,9 +12,6 @@ import seedu.address.model.appointment.Appointment;
  */
 public class EditAppointmentDescriptorBuilder {
     private EditAppointmentDescriptor descriptor;
-    private LocalTime startTime;
-    private LocalTime endTime;
-    private LocalDate date;
     private DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     private DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
 
@@ -32,15 +28,16 @@ public class EditAppointmentDescriptorBuilder {
      */
     public EditAppointmentDescriptorBuilder(Appointment appointment) {
         descriptor = new EditAppointmentDescriptor();
-        descriptor.setStartTime(appointment.getStartTime());
-        descriptor.setEndTime(appointment.getEndTime());
+        descriptor.setDate(appointment.getStartTime().toLocalDate());
+        descriptor.setStartTime(appointment.getStartTime().toLocalTime());
+        descriptor.setEndTime(appointment.getEndTime().toLocalTime());
     }
 
     /**
      * Sets the {@code date} of the {@code EditAppointmentDescriptor} that we are building.
      */
     public EditAppointmentDescriptorBuilder withDate(String date) {
-        this.date = LocalDate.parse(date, dateFormatter);
+        descriptor.setDate(LocalDate.parse(date, dateFormatter));
         return this;
     }
 
@@ -48,11 +45,7 @@ public class EditAppointmentDescriptorBuilder {
      * Sets the {@code startTime} of the {@code EditAppointmentDescriptor} that we are building.
      */
     public EditAppointmentDescriptorBuilder withStartTime(String startTime) {
-        this.startTime = LocalTime.parse(startTime, timeFormatter);
-        System.out.println("here" + this.date + this.startTime);
-        if (this.date != null && this.startTime != null) {
-            descriptor.setStartTime(LocalDateTime.of(date, this.startTime));
-        }
+        descriptor.setStartTime(LocalTime.parse(startTime, timeFormatter));
         return this;
     }
 
@@ -60,10 +53,7 @@ public class EditAppointmentDescriptorBuilder {
      * Sets the {@code endTime} of the {@code EditAppointmentDescriptor} that we are building.
      */
     public EditAppointmentDescriptorBuilder withEndTime(String endTime) {
-        this.endTime = LocalTime.parse(endTime, timeFormatter);
-        if (this.date != null && this.endTime != null) {
-            descriptor.setEndTime(LocalDateTime.of(date, this.endTime));
-        }
+        descriptor.setEndTime(LocalTime.parse(endTime, timeFormatter));
         return this;
     }
 


### PR DESCRIPTION
- Date, start time and end time are now optional fields, but at least one field must be edited
- #160 