### PR TITLE
Add status change command for appointments

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UpdateAppointmentStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateAppointmentStatusCommand.java
@@ -79,4 +79,18 @@ public class UpdateAppointmentStatusCommand extends Command {
 
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        UpdateAppointmentStatusCommand otherCommand = (UpdateAppointmentStatusCommand) other;
+        return nric.equals(otherCommand.nric)
+            && startDateTime.equals(otherCommand.startDateTime)
+            && status.equals(otherCommand.status);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/UpdateAppointmentStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateAppointmentStatusCommand.java
@@ -1,0 +1,82 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.Status;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+
+/**
+ * Updates the status of an appointment.
+ */
+public class UpdateAppointmentStatusCommand extends Command {
+
+    public static final String COMMAND_WORD = "updatestatus";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Updates the status of an appointment.\n"
+        + "By the patient's NRIC number"
+        + "\nParameters: "
+        + PREFIX_NRIC + "PATIENT_NRIC\n"
+        + PREFIX_DATE + "DATE (DD/MM/YYYY) \n"
+        + PREFIX_START_TIME + "START_TIME (HH:MM) \n"
+        + PREFIX_STATUS + "STATUS\n"
+        + "Example: " + COMMAND_WORD + " "
+        + PREFIX_NRIC + "S1234567A "
+        + PREFIX_DATE + "01/01/2021 "
+        + PREFIX_START_TIME + "10:00 "
+        + PREFIX_STATUS + "COMPLETED";
+
+    public static final String MESSAGE_SUCCESS = "Appointment status updated: %1$s";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "Incorrect NRIC. Person not found";
+    public static final String MESSAGE_INVALID_DATE = "Invalid date. Please use the DD/MM/YYYY format";
+    public static final String MESSAGE_INVALID_TIME = "Invalid time. Please use the HH:MM format";
+    public static final String MESSAGE_NO_APPOINTMENT = "This appointment does not exist in CareLink";
+
+    private final Nric nric;
+    private final LocalDateTime startDateTime;
+    private final Status status;
+
+    /**
+     * Constructor for UpdateAppointmentStatusCommand.
+     * @param nric the NRIC of the person to update the appointment status
+     * @param date the date of the appointment
+     * @param startTime the start time of the appointment
+     * @param status the status of the appointment
+     */
+    public UpdateAppointmentStatusCommand(Nric nric, LocalDate date, LocalTime startTime, Status status) {
+        this.nric = nric;
+        this.startDateTime = LocalDateTime.of(date, startTime);
+        this.status = status;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+
+        requireNonNull(model);
+
+        Person person = model.getPerson(nric);
+
+        if (person == null) {
+            throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
+        }
+
+        Appointment appointment = model.getAppointmentForPersonAndTime(person, startDateTime);
+        if (appointment == null) {
+            throw new CommandException(MESSAGE_NO_APPOINTMENT);
+        }
+        model.updateAppointmentStatus(appointment, status);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, status));
+
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.LinkCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UpdateAppointmentStatusCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -104,6 +105,9 @@ public class AddressBookParser {
 
         case AddNoteCommand.COMMAND_WORD:
             return new AddNoteCommandParser().parse(arguments);
+
+        case UpdateAppointmentStatusCommand.COMMAND_WORD:
+            return new UpdateAppointmentStatusParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -25,5 +25,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_NEW_DATE = new Prefix("newd/");
     public static final Prefix PREFIX_NEW_START_TIME = new Prefix("newstart/");
     public static final Prefix PREFIX_NEW_END_TIME = new Prefix("newend/");
+    public static final Prefix PREFIX_STATUS = new Prefix("status/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.AddAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Status;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -229,6 +230,23 @@ public class ParserUtil {
             throw new ParseException(Note.MESSAGE_CONSTRAINTS);
         }
         return new Note(trimmedInput);
+    }
+
+    /**
+     * Parses a {@code String input} into a {@code Status}.
+     * The input string is expected to be either "COMPLETED" or "PENDING".
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @param input the status string to be parsed
+     * @return the parsed {@code Status} object
+     * @throws ParseException if the input does not conform to the expected format
+     */
+    public static Status parseStatus(String input) throws ParseException {
+        String trimmedInput = input.trim();
+        if (!Status.isValidStatus(trimmedInput)) {
+            throw new ParseException(Status.MESSAGE_CONSTRAINTS);
+        }
+        return Status.valueOf(trimmedInput.toUpperCase());
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/UpdateAppointmentStatusParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateAppointmentStatusParser.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.UpdateAppointmentStatusCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Status;
+import seedu.address.model.person.Nric;
+
+/**
+ * Parses input arguments and creates a new UpdateAppointmentStatusCommand object
+ */
+public class UpdateAppointmentStatusParser implements Parser<UpdateAppointmentStatusCommand> {
+
+    @Override
+    public UpdateAppointmentStatusCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_NRIC,
+            PREFIX_DATE, PREFIX_START_TIME, PREFIX_STATUS);
+
+        if (!arePrefixesPresent(argumentMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME, PREFIX_STATUS)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                UpdateAppointmentStatusCommand.MESSAGE_USAGE));
+        }
+
+        Nric nric = ParserUtil.parseNric(argumentMultimap.getValue(PREFIX_NRIC).get());
+        LocalDate date = ParserUtil.parseDate(argumentMultimap.getValue(PREFIX_DATE).get());
+        LocalTime startTime = ParserUtil.parseTime(argumentMultimap.getValue(PREFIX_START_TIME).get());
+        Status status = ParserUtil.parseStatus(argumentMultimap.getValue(PREFIX_STATUS).get());
+
+        return new UpdateAppointmentStatusCommand(nric, date, startTime, status);
+
+    }
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/UpdateAppointmentStatusParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateAppointmentStatusParser.java
@@ -25,6 +25,11 @@ public class UpdateAppointmentStatusParser implements Parser<UpdateAppointmentSt
         ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_NRIC,
             PREFIX_DATE, PREFIX_START_TIME, PREFIX_STATUS);
 
+        if (!argumentMultimap.getPreamble().equals("")) {
+            throw new ParseException("Please do not enter anything before the keywords!\n"
+            + "Please remove this from your input: " + argumentMultimap.getPreamble());
+        }
+
         if (!arePrefixesPresent(argumentMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME, PREFIX_STATUS)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 UpdateAppointmentStatusCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/model/AppointmentManager.java
+++ b/src/main/java/seedu/address/model/AppointmentManager.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.Status;
 import seedu.address.model.person.Person;
 
 /**
@@ -136,5 +137,16 @@ public class AppointmentManager {
         allAppointments.sort(Comparator.comparing(Appointment::getStartTime));
 
         return allAppointments;
+    }
+
+    /**
+     * Updates the status of an existing appointment.
+     *
+     * @param appointment The appointment to be updated.
+     * @param status The new status of the appointment.
+     */
+    public void updateAppointmentStatus(Appointment appointment, Status status) {
+        appointment.setStatus(status);
+        update();
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.Status;
 import seedu.address.model.person.Note;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
@@ -113,6 +114,8 @@ public interface Model {
     Appointment getAppointmentForPersonAndTime(Person person, LocalDateTime startTime);
 
     boolean hasAppointment(Appointment appointment);
+
+    void updateAppointmentStatus(Appointment appointment, Status status);
 
     void addNoteToPerson(Note note, Person person);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -16,6 +16,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.Status;
 import seedu.address.model.person.Note;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
@@ -224,6 +225,11 @@ public class ModelManager implements Model {
         requireNonNull(appointment);
         appointmentManager.update();
         return appointmentManager.hasAppointment(appointment);
+    }
+
+    @Override
+    public void updateAppointmentStatus(Appointment appointment, Status status) {
+        appointmentManager.updateAppointmentStatus(appointment, status);
     }
 
     public void addNoteToPerson(Note note, Person person) {

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -21,6 +21,8 @@ public class Appointment {
     private final LocalDateTime startTime;
     private final LocalDateTime endTime;
 
+    private Status status;
+
     private boolean isCompleted = false;
 
     /**
@@ -39,6 +41,7 @@ public class Appointment {
         this.nric = nric;
         this.startTime = startTime;
         this.endTime = endTime;
+        this.status = Status.PENDING;
     }
 
     /**
@@ -59,6 +62,31 @@ public class Appointment {
         this.startTime = startTime;
         this.endTime = endTime;
         this.isCompleted = isCompleted;
+        this.status = Status.COMPLETED;
+    }
+
+    /**
+     * Constructs an appointment with the given details, completion status, and status.
+     *
+     * @param name the name of the appointment
+     * @param nric the nric of the patient
+     * @param startTime the start time of the appointment
+     * @param endTime the end time of the appointment
+     * @param isCompleted the completion status of the appointment
+     * @param status the status of the appointment
+     */
+
+    public Appointment(String name, Nric nric, LocalDateTime startTime, LocalDateTime endTime,
+        boolean isCompleted, Status status) {
+        if (startTime.isAfter(endTime) || startTime.equals(endTime)) {
+            throw new InvalidAppointmentException(INVALID_APPOINTMENT_ERROR);
+        }
+        this.name = name;
+        this.nric = nric;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.isCompleted = isCompleted;
+        this.status = status;
     }
 
     /**
@@ -97,10 +125,43 @@ public class Appointment {
     }
 
     /**
+     * @return the status of the appointment
+     */
+    public Status getStatus() {
+        return status;
+    }
+
+    /**
      * Marks the appointment as completed.
      */
     public void markAsCompleted() {
         isCompleted = true;
+        status = Status.COMPLETED;
+    }
+
+    /**
+     * Marks the appointment as not completed.
+     */
+    public void markAsNotCompleted() {
+        isCompleted = false;
+        status = Status.PENDING;
+    }
+
+    /**
+     * Sets the status of the appointment.
+     *
+     * If the status is COMPLETED, the appointment is marked as completed.
+     * If the status is PENDING, the appointment is marked as not completed.
+     *
+     * @param status the status to set
+     */
+    public void setStatus(Status status) {
+        this.status = status;
+        if (status == Status.COMPLETED) {
+            this.markAsCompleted();
+        } else {
+            this.markAsNotCompleted();
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/appointment/Status.java
+++ b/src/main/java/seedu/address/model/appointment/Status.java
@@ -1,0 +1,31 @@
+package seedu.address.model.appointment;
+
+/**
+ * Represents the status of an appointment in the address book.
+ */
+public enum Status {
+
+    COMPLETED,
+    PENDING;
+
+    public static final String MESSAGE_CONSTRAINTS = "Status should only be 'COMPLETED' or 'PENDING'";
+
+    /**
+     * Checks if the given string matches any of the defined statuses (case-insensitive).
+     *
+     * @param status The status string to check.
+     * @return true if the status is valid, false otherwise.
+     */
+    public static boolean isValidStatus(String status) {
+        if (status == null) {
+            return false;
+        }
+
+        try {
+            Status.valueOf(status.trim().toUpperCase());
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.Status;
 import seedu.address.model.person.Nric;
 
 
@@ -22,6 +23,7 @@ class JsonAdaptedAppointment {
     private final String startTime;
     private final String endTime;
     private final boolean isCompleted;
+    private final String status;
 
     /**
      * Constructs a {@code JsonAdaptedAppointment} with the given appointment details.
@@ -32,12 +34,14 @@ class JsonAdaptedAppointment {
             @JsonProperty("nric") String nric,
             @JsonProperty("startTime") String startTime,
             @JsonProperty("endTime") String endTime,
-            @JsonProperty("isCompleted") boolean isCompleted) {
+            @JsonProperty("isCompleted") boolean isCompleted,
+            @JsonProperty("status") String status) {
         this.name = name;
         this.nric = nric;
         this.startTime = startTime;
         this.endTime = endTime;
         this.isCompleted = isCompleted;
+        this.status = status;
     }
 
     /**
@@ -49,6 +53,7 @@ class JsonAdaptedAppointment {
         startTime = source.getStartTime().toString();
         endTime = source.getEndTime().toString();
         isCompleted = source.isCompleted();
+        status = source.getStatus().toString();
     }
 
     /**
@@ -83,7 +88,13 @@ class JsonAdaptedAppointment {
             throw new IllegalValueException("End time cannot be before start time.");
         }
 
+        if (status == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Status"));
+        }
+
+        Status status = Status.valueOf(this.status);
+
         // Use the new constructor that accepts isCompleted as a parameter
-        return new Appointment(name, modelNric, modelStartTime, modelEndTime, isCompleted);
+        return new Appointment(name, modelNric, modelStartTime, modelEndTime, isCompleted, status);
     }
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -1,128 +1,132 @@
 {
-    "_comment": "AddressBook save file which contains the updated Person values with more attributes",
-    "persons": [
+  "_comment": "AddressBook save file which contains the updated Person values with more attributes",
+  "persons": [
+    {
+      "name": "Alice Pauline",
+      "nric": "S6283947C",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tags": ["backPain"],
+      "roles": ["PATIENT"],
+      "caregivers": ["S9876543C"],
+      "patients": [],
+      "appointments": [
         {
-            "name": "Alice Pauline",
-            "nric": "S6283947C",
-            "phone": "94351253",
-            "email": "alice@example.com",
-            "address": "123, Jurong West Ave 6, #08-111",
-            "tags": ["backPain"],
-            "roles": ["PATIENT"],
-            "caregivers": ["S9876543C"],
-            "patients": [],
-            "appointments": [
-                {
-                    "name": "Alice Pauline",
-                    "nric": "S6283947C",
-                    "startTime": "2025-01-01T10:00",
-                    "endTime": "2025-01-01T11:00",
-                    "isCompleted": false
-                }
-            ],
-            "notes": ["Follow up on blood pressure medication."]
-        },
-        {
-            "name": "Benson Meier",
-            "nric": "S7012345B",
-            "phone": "98765432",
-            "email": "johnd@example.com",
-            "address": "311, Clementi Ave 2, #02-25",
-            "tags": ["shortOfTime", "nurseBefore"],
-            "roles": ["PATIENT"],
-            "caregivers": ["S8765432Z"],
-            "patients": [],
-            "appointments": [
-                {
-                    "name": "Benson Meier",
-                    "nric": "S7012345B",
-                    "startTime": "2025-02-10T14:00",
-                    "endTime": "2025-02-10T15:00",
-                    "isCompleted": false
-                }
-            ],
-            "notes": ["Review arthritis medication plan."]
-        },
-        {
-            "name": "Carl Kurz",
-            "nric": "S7193475F",
-            "phone": "95352563",
-            "email": "heinz@example.com",
-            "address": "wall street",
-            "tags": [],
-            "roles": ["PATIENT"],
-            "caregivers": ["S7890123C"],
-            "patients": [],
-            "appointments": [
-                {
-                    "name": "Charlotte Oliveiro",
-                    "nric": "S7193475F",
-                    "startTime": "2025-03-15T09:00",
-                    "endTime": "2025-03-15T10:00",
-                    "isCompleted": false
-                }
-            ],
-            "notes": ["Schedule fall risk assessment."]
-        },
-        {
-            "name": "Daniel Meier",
-            "nric": "S6483749D",
-            "phone": "87652533",
-            "email": "cornelia@example.com",
-            "address": "10th street",
-            "tags": ["friends"],
-            "roles": ["PATIENT"],
-            "caregivers": ["S2345678H"],
-            "patients": [],
-            "appointments": [
-                {
-                    "name": "Daniel Meier",
-                    "nric": "S6483749D",
-                    "startTime": "2025-04-05T13:00",
-                    "endTime": "2025-04-05T14:00",
-                    "isCompleted": false
-                }
-            ],
-            "notes": ["Consider referral for physical therapy."]
-        },
-        {
-            "name": "Elle Meyer",
-            "nric": "S6382947A",
-            "phone": "9482224",
-            "email": "werner@example.com",
-            "address": "michegan ave",
-            "tags": [],
-            "roles": ["CAREGIVER"],
-            "caregivers": [],
-            "patients": ["S2345678H"],
-            "appointments": [],
-            "notes": ["Provide support for medication management."]
-        },
-        {
-            "name": "Fiona Kunz",
-            "nric": "S6482983A",
-            "phone": "9482427",
-            "email": "lydia@example.com",
-            "address": "little tokyo",
-            "tags": [],
-            "roles": ["PATIENT"],
-            "caregivers": [],
-            "patients": [],
-            "appointments": [],
-            "notes": ["Regular check-up scheduled."]
-        },
-        {
-            "name": "George Best",
-            "nric": "G3536933W",
-            "phone": "9482442",
-            "email": "anna@example.com",
-            "address": "4th street",
-            "tags": [],
-            "roles": ["CAREGIVER"],
-            "caregivers": [],
-            "patients": ["S6283947C"],
-            "appointments": [],
-            "notes": ["Assist Alex with daily tasks."]
+          "name": "Alice Pauline",
+          "nric": "S6283947C",
+          "startTime": "2025-01-01T10:00",
+          "endTime": "2025-01-01T11:00",
+          "isCompleted": false,
+          "status": "PENDING"
         }
-    ]
+      ],
+      "notes": ["Follow up on blood pressure medication."]
+    },
+    {
+      "name": "Benson Meier",
+      "nric": "S7012345B",
+      "phone": "98765432",
+      "email": "johnd@example.com",
+      "address": "311, Clementi Ave 2, #02-25",
+      "tags": ["shortOfTime", "nurseBefore"],
+      "roles": ["PATIENT"],
+      "caregivers": ["S8765432Z"],
+      "patients": [],
+      "appointments": [
+        {
+          "name": "Benson Meier",
+          "nric": "S7012345B",
+          "startTime": "2025-02-10T14:00",
+          "endTime": "2025-02-10T15:00",
+          "isCompleted": false,
+          "status": "PENDING"
+        }
+      ],
+      "notes": ["Review arthritis medication plan."]
+    },
+    {
+      "name": "Carl Kurz",
+      "nric": "S7193475F",
+      "phone": "95352563",
+      "email": "heinz@example.com",
+      "address": "wall street",
+      "tags": [],
+      "roles": ["PATIENT"],
+      "caregivers": ["S7890123C"],
+      "patients": [],
+      "appointments": [
+        {
+          "name": "Charlotte Oliveiro",
+          "nric": "S7193475F",
+          "startTime": "2025-03-15T09:00",
+          "endTime": "2025-03-15T10:00",
+          "isCompleted": false,
+          "status": "PENDING"
+        }
+      ],
+      "notes": ["Schedule fall risk assessment."]
+    },
+    {
+      "name": "Daniel Meier",
+      "nric": "S6483749D",
+      "phone": "87652533",
+      "email": "cornelia@example.com",
+      "address": "10th street",
+      "tags": ["friends"],
+      "roles": ["PATIENT"],
+      "caregivers": ["S2345678H"],
+      "patients": [],
+      "appointments": [
+        {
+          "name": "Daniel Meier",
+          "nric": "S6483749D",
+          "startTime": "2025-04-05T13:00",
+          "endTime": "2025-04-05T14:00",
+          "isCompleted": false,
+          "status": "PENDING"
+        }
+      ],
+      "notes": ["Consider referral for physical therapy."]
+    },
+    {
+      "name": "Elle Meyer",
+      "nric": "S6382947A",
+      "phone": "9482224",
+      "email": "werner@example.com",
+      "address": "michegan ave",
+      "tags": [],
+      "roles": ["CAREGIVER"],
+      "caregivers": [],
+      "patients": ["S2345678H"],
+      "appointments": [],
+      "notes": ["Provide support for medication management."]
+    },
+    {
+      "name": "Fiona Kunz",
+      "nric": "S6482983A",
+      "phone": "9482427",
+      "email": "lydia@example.com",
+      "address": "little tokyo",
+      "tags": [],
+      "roles": ["PATIENT"],
+      "caregivers": [],
+      "patients": [],
+      "appointments": [],
+      "notes": ["Regular check-up scheduled."]
+    },
+    {
+      "name": "George Best",
+      "nric": "G3536933W",
+      "phone": "9482442",
+      "email": "anna@example.com",
+      "address": "4th street",
+      "tags": [],
+      "roles": ["CAREGIVER"],
+      "caregivers": [],
+      "patients": ["S6283947C"],
+      "appointments": [],
+      "notes": ["Assist Alex with daily tasks."]
+    }
+  ]
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.Status;
 import seedu.address.model.person.Note;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
@@ -238,6 +239,11 @@ public class AddCommandTest {
 
         @Override
         public void editAppointment(Appointment appointmentToEdit, Person person, Appointment editedAppointment) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateAppointmentStatus(Appointment appointment, Status status) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -189,6 +189,7 @@ public class CommandTestUtil {
     public static final String VALID_STATUS_COMPLETED_DESC = " " + PREFIX_STATUS + VALID_STATUS_COMPLETED;
     public static final String VALID_STATUS_PENDING_DESC = " " + PREFIX_STATUS + VALID_STATUS_PENDING;
     public static final String INVALID_STATUS_DESC = " " + PREFIX_STATUS + INVALID_STATUS_CANCELLED;
+    public static final String INVALID_STATUS_DESC_NULL = " " + PREFIX_STATUS;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).withNric(VALID_NRIC_AMY)

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -16,6 +16,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -149,6 +150,10 @@ public class CommandTestUtil {
             LocalDate.parse(VALID_DATE_APPOINTMENT, DATE_FORMATTER),
             LocalTime.parse(VALID_START_TIME_APPOINTMENT, TIME_FORMATTER));
 
+    public static final String VALID_STATUS_COMPLETED = "COMPLETED";
+    public static final String VALID_STATUS_PENDING = "PENDING";
+    public static final String INVALID_STATUS_CANCELLED = "CANCELLED";
+
     public static final String INVALID_DATE_APPOINTMENT = "2025/10/10"; // Invalid date format in YYYY/MM/DD format
     public static final String VALID_END_TIME_APPOINTMENT = "11:00"; // Example end time in HH:mm format
 
@@ -180,6 +185,10 @@ public class CommandTestUtil {
 
     public static final String INVALID_DATE_DESC_APPOINTMENT = " " + PREFIX_DATE
             + INVALID_DATE_APPOINTMENT; // Invalid date format in YYYY/MM/DD format
+
+    public static final String VALID_STATUS_COMPLETED_DESC = " " + PREFIX_STATUS + VALID_STATUS_COMPLETED;
+    public static final String VALID_STATUS_PENDING_DESC = " " + PREFIX_STATUS + VALID_STATUS_PENDING;
+    public static final String INVALID_STATUS_DESC = " " + PREFIX_STATUS + INVALID_STATUS_CANCELLED;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).withNric(VALID_NRIC_AMY)

--- a/src/test/java/seedu/address/logic/commands/UpdateAppointmentStatusCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateAppointmentStatusCommandTest.java
@@ -1,0 +1,106 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.Status;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+public class UpdateAppointmentStatusCommandTest {
+
+    private static final Nric VALID_NRIC = new PersonBuilder().build().getNric();
+    private static final LocalDate VALID_DATE = LocalDate.of(2025, 10, 22);
+    private static final LocalTime VALID_START_TIME = LocalTime.of(10, 0);
+    private static final LocalTime VALID_END_TIME = LocalTime.of(11, 0);
+    private static final Status VALID_STATUS_COMPLETED = Status.COMPLETED;
+    private static final Status VALID_STATUS_PENDING = Status.PENDING;
+
+    @Test
+    public void constructor_nullInputs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new UpdateAppointmentStatusCommand(null, null, null, null));
+    }
+
+    @Test
+    public void execute_validInput_success() {
+        Model modelStub = new ModelManager();
+        Person testPerson = new PersonBuilder().build();
+        modelStub.addPerson(testPerson);
+        Appointment validAppointment = new Appointment(testPerson.getName().toString(), testPerson.getNric(),
+                                LocalDateTime.of(VALID_DATE, VALID_START_TIME),
+                                LocalDateTime.of(VALID_DATE, VALID_END_TIME));
+
+        modelStub.addAppointment(validAppointment, testPerson);
+        UpdateAppointmentStatusCommand updateAppointmentStatusCommand = new UpdateAppointmentStatusCommand(
+                VALID_NRIC, VALID_DATE, VALID_START_TIME, VALID_STATUS_COMPLETED);
+        String expectedMessage = String.format(UpdateAppointmentStatusCommand.MESSAGE_SUCCESS, VALID_STATUS_COMPLETED);
+        Model expectedModelStub = new ModelManager();
+        Person expectedTestPerson = new PersonBuilder().build();
+        expectedModelStub.addPerson(expectedTestPerson);
+        expectedModelStub.addAppointment(validAppointment, expectedTestPerson);
+        expectedModelStub.updateAppointmentStatus(validAppointment, VALID_STATUS_COMPLETED);
+        assertCommandSuccess(updateAppointmentStatusCommand, modelStub, expectedMessage, expectedModelStub);
+    }
+
+    @Test
+    public void execute_invalidNric() {
+        Model modelStub = new ModelManager();
+
+        UpdateAppointmentStatusCommand updateAppointmentStatusCommand = new UpdateAppointmentStatusCommand(
+            VALID_NRIC, VALID_DATE, VALID_START_TIME, VALID_STATUS_PENDING);
+        String expectedMessage = String.format(UpdateAppointmentStatusCommand.MESSAGE_PERSON_NOT_FOUND, VALID_NRIC);
+
+        assertCommandFailure(updateAppointmentStatusCommand, modelStub, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidAppointment() {
+        Model modelStub = new ModelManager();
+        Person testPerson = new PersonBuilder().build();
+        modelStub.addPerson(testPerson);
+        UpdateAppointmentStatusCommand updateAppointmentStatusCommand = new UpdateAppointmentStatusCommand(
+            VALID_NRIC, VALID_DATE, VALID_START_TIME, VALID_STATUS_PENDING);
+        String expectedMessage = String.format(UpdateAppointmentStatusCommand.MESSAGE_NO_APPOINTMENT);
+
+        assertCommandFailure(updateAppointmentStatusCommand, modelStub, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        UpdateAppointmentStatusCommand updateAppointmentStatusCommand1 = new UpdateAppointmentStatusCommand(VALID_NRIC,
+            VALID_DATE, VALID_START_TIME, VALID_STATUS_PENDING);
+        UpdateAppointmentStatusCommand updateAppointmentStatusCommand2 = new UpdateAppointmentStatusCommand(VALID_NRIC,
+            VALID_DATE, VALID_START_TIME, VALID_STATUS_PENDING);
+
+        // same object -> returns true
+        assertTrue(updateAppointmentStatusCommand1.equals(updateAppointmentStatusCommand1));
+
+        // same values -> returns true
+        assertTrue(updateAppointmentStatusCommand1.equals(updateAppointmentStatusCommand2));
+
+        // different types -> returns false
+        assertFalse(updateAppointmentStatusCommand1.equals(1));
+
+        // null -> returns false
+        assertFalse(updateAppointmentStatusCommand1.equals(null));
+
+        // different appointment -> returns false
+        UpdateAppointmentStatusCommand updateAppointmentStatusCommand3 = new UpdateAppointmentStatusCommand(VALID_NRIC,
+            VALID_DATE, LocalTime.of(12, 0), VALID_STATUS_PENDING);
+        assertFalse(updateAppointmentStatusCommand1.equals(updateAppointmentStatusCommand3));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -30,9 +30,11 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.LinkCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UpdateAppointmentStatusCommand;
 import seedu.address.logic.parser.criteria.NameSearchCriteria;
 import seedu.address.logic.parser.criteria.SearchCriteria;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Status;
 import seedu.address.model.person.ContainsKeywordsPredicate;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
@@ -123,6 +125,21 @@ public class AddressBookParserTest {
         );
         assertEquals(new DeleteAppointmentCommand(validNric, LocalDate.parse(validDate, dateFormatter),
             LocalTime.parse(validStartTime, timeFormatter)), command);
+    }
+
+    @Test
+    public void parseCommand_updateAppointmentStatus() throws Exception {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+        Nric validNric = new PersonBuilder().build().getNric();
+        String validDate = "22/10/2025";
+        String validStartTime = "10:00";
+        String validStatus = "COMPLETED";
+        UpdateAppointmentStatusCommand command = (UpdateAppointmentStatusCommand) parser.parseCommand(
+                PersonUtil.getUpdateAppointmentStatusCommand(validNric, validDate, validStartTime, validStatus)
+        );
+        assertEquals(new UpdateAppointmentStatusCommand(validNric, LocalDate.parse(validDate, dateFormatter),
+            LocalTime.parse(validStartTime, timeFormatter), Status.COMPLETED), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UpdateAppointmentStatusParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateAppointmentStatusParserTest.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC_APPOINTMENT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_APPOINTMENT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_DESC_APPOINTMENT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_APPOINTMENT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_DESC_APPOINTMENT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_COMPLETED_DESC;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UpdateAppointmentStatusCommand;
+import seedu.address.model.appointment.Status;
+import seedu.address.model.person.Nric;
+
+public class UpdateAppointmentStatusParserTest {
+
+    private UpdateAppointmentStatusParser parser = new UpdateAppointmentStatusParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        UpdateAppointmentStatusCommand expectedCommand = new UpdateAppointmentStatusCommand(
+            new Nric(VALID_NRIC_AMY),
+            LocalDate.parse(VALID_DATE_APPOINTMENT, dateFormatter),
+            LocalTime.parse(VALID_START_TIME_APPOINTMENT, timeFormatter),
+            Status.COMPLETED
+        );
+
+        assertParseSuccess(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT
+            + VALID_START_TIME_DESC_APPOINTMENT + VALID_STATUS_COMPLETED_DESC, expectedCommand);
+    }
+
+    @Test
+    public void parse_optionalFieldsMissing_failure() {
+        // Missing NRIC
+        assertParseFailure(parser, VALID_DATE_DESC_APPOINTMENT + VALID_START_TIME_DESC_APPOINTMENT
+            + VALID_STATUS_COMPLETED_DESC,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, UpdateAppointmentStatusCommand.MESSAGE_USAGE));
+
+        // Missing date
+        assertParseFailure(parser, NRIC_DESC_AMY + VALID_START_TIME_DESC_APPOINTMENT + VALID_STATUS_COMPLETED_DESC,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, UpdateAppointmentStatusCommand.MESSAGE_USAGE));
+
+        // Missing start time
+        assertParseFailure(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT + VALID_STATUS_COMPLETED_DESC,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, UpdateAppointmentStatusCommand.MESSAGE_USAGE));
+
+        // Missing status
+        assertParseFailure(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT + VALID_START_TIME_DESC_APPOINTMENT,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, UpdateAppointmentStatusCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidNric_failure() {
+        // Invalid NRIC
+        assertParseFailure(parser, INVALID_NRIC_DESC + VALID_DATE_DESC_APPOINTMENT
+            + VALID_START_TIME_DESC_APPOINTMENT + VALID_STATUS_COMPLETED_DESC, Nric.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidDateFormat_failure() {
+        // Invalid date format
+        assertParseFailure(parser, NRIC_DESC_AMY + INVALID_DATE_DESC_APPOINTMENT + VALID_START_TIME_DESC_APPOINTMENT
+            + VALID_STATUS_COMPLETED_DESC, UpdateAppointmentStatusCommand.MESSAGE_INVALID_DATE);
+    }
+
+    @Test
+    public void parse_invalidStartTimeFormat_failure() {
+        // Invalid start time format
+        assertParseFailure(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT + INVALID_START_TIME_DESC
+            + VALID_STATUS_COMPLETED_DESC,
+            UpdateAppointmentStatusCommand.MESSAGE_INVALID_TIME);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/UpdateAppointmentStatusParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateAppointmentStatusParserTest.java
@@ -4,6 +4,8 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC_APPOINTMENT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_STATUS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_STATUS_DESC_NULL;
 import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_APPOINTMENT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_DESC_APPOINTMENT;
@@ -84,6 +86,20 @@ public class UpdateAppointmentStatusParserTest {
         assertParseFailure(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT + INVALID_START_TIME_DESC
             + VALID_STATUS_COMPLETED_DESC,
             UpdateAppointmentStatusCommand.MESSAGE_INVALID_TIME);
+    }
+
+    @Test
+    public void parse_invalidStatus_failure() {
+        // Invalid status
+        assertParseFailure(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT + VALID_START_TIME_DESC_APPOINTMENT
+            + INVALID_STATUS_DESC, Status.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidStatus_failureNull() {
+        // Invalid status
+        assertParseFailure(parser, NRIC_DESC_AMY + VALID_DATE_DESC_APPOINTMENT + VALID_START_TIME_DESC_APPOINTMENT
+            + INVALID_STATUS_DESC_NULL, Status.MESSAGE_CONSTRAINTS);
     }
 
 }

--- a/src/test/java/seedu/address/model/appointment/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentTest.java
@@ -106,6 +106,38 @@ public class AppointmentTest {
     }
 
     @Test
+    public void markAsUncompletedTest() {
+        Person testPerson = new PersonBuilder().build();
+        LocalDateTime startTime = LocalDateTime.of(2024, 10, 22, 12, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 10, 22, 12, 0).plusHours(1);
+
+        // Create an appointment with the completed flag set to true
+        Appointment appointment = new Appointment("Incomplete Appointment", testPerson.getNric(),
+            startTime, endTime, true);
+        assertTrue(appointment.isCompleted());
+
+        // Mark as not completed and check again
+        appointment.markAsNotCompleted();
+        assertFalse(appointment.isCompleted());
+    }
+
+    @Test
+    public void setStatusPending() {
+        Person testPerson = new PersonBuilder().build();
+        LocalDateTime startTime = LocalDateTime.of(2024, 10, 22, 12, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 10, 22, 12, 0).plusHours(1);
+
+        // Create an appointment with the completed flag set to true
+        Appointment appointment = new Appointment("Incomplete Appointment", testPerson.getNric(),
+            startTime, endTime, true);
+        assertTrue(appointment.isCompleted());
+
+        // Change status and check again
+        appointment.setStatus(Status.PENDING);
+        assertFalse(appointment.isCompleted());
+    }
+
+    @Test
     public void toStringTest() {
         Person testPerson = new PersonBuilder().build();
         LocalDateTime startTime = LocalDateTime.of(2024, 10, 22, 12, 0);

--- a/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
@@ -19,6 +19,8 @@ public class JsonAdaptedAppointmentTest {
     private static final String VALID_START_TIME = LocalDateTime.of(2024, 10, 22, 12, 0).toString();
     private static final String VALID_END_TIME = LocalDateTime.of(2024, 10, 22, 12, 0).plusHours(1).toString();
     private static final boolean VALID_IS_COMPLETED = false;
+    private static final String VALID_IS_PENDING_STATUS = "PENDING";
+
 
     private static final String INVALID_NRIC = "INVALID_NRIC";
     private static final String INVALID_START_TIME = "INVALID_START_TIME";
@@ -27,7 +29,7 @@ public class JsonAdaptedAppointmentTest {
     @Test
     public void toModelType_validAppointment_returnsAppointment() throws Exception {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_NAME, VALID_NRIC,
-                VALID_START_TIME, VALID_END_TIME, VALID_IS_COMPLETED);
+                VALID_START_TIME, VALID_END_TIME, VALID_IS_COMPLETED, VALID_IS_PENDING_STATUS);
         Appointment expectedAppointment = new Appointment(VALID_NAME, new Nric(VALID_NRIC),
                 LocalDateTime.parse(VALID_START_TIME), LocalDateTime.parse(VALID_END_TIME), VALID_IS_COMPLETED);
         assertEquals(expectedAppointment, appointment.toModelType());
@@ -36,7 +38,7 @@ public class JsonAdaptedAppointmentTest {
     @Test
     public void toModelType_invalidNric_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_NAME, INVALID_NRIC,
-                VALID_START_TIME, VALID_END_TIME, VALID_IS_COMPLETED);
+                VALID_START_TIME, VALID_END_TIME, VALID_IS_COMPLETED, VALID_IS_PENDING_STATUS);
         String expectedMessage = Nric.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
     }
@@ -44,35 +46,35 @@ public class JsonAdaptedAppointmentTest {
     @Test
     public void toModelType_invalidStartTime_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_NAME, VALID_NRIC,
-                INVALID_START_TIME, VALID_END_TIME, VALID_IS_COMPLETED);
+                INVALID_START_TIME, VALID_END_TIME, VALID_IS_COMPLETED, VALID_IS_PENDING_STATUS);
         assertThrows(IllegalValueException.class, appointment::toModelType);
     }
 
     @Test
     public void toModelType_invalidEndTime_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_NAME, VALID_NRIC,
-                VALID_START_TIME, INVALID_END_TIME, VALID_IS_COMPLETED);
+                VALID_START_TIME, INVALID_END_TIME, VALID_IS_COMPLETED, VALID_IS_PENDING_STATUS);
         assertThrows(IllegalValueException.class, appointment::toModelType);
     }
 
     @Test
     public void toModelType_nullNric_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_NAME, null,
-                VALID_START_TIME, VALID_END_TIME, VALID_IS_COMPLETED);
+                VALID_START_TIME, VALID_END_TIME, VALID_IS_COMPLETED, VALID_IS_PENDING_STATUS);
         String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT, "Nric");
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
     }
     @Test
     public void toModelType_nullStartTime_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_NAME, VALID_NRIC,
-                null, VALID_END_TIME, VALID_IS_COMPLETED);
+                null, VALID_END_TIME, VALID_IS_COMPLETED, VALID_IS_PENDING_STATUS);
         assertThrows(IllegalValueException.class, appointment::toModelType);
     }
 
     @Test
     public void toModelType_nullEndTime_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_NAME, VALID_NRIC,
-                VALID_START_TIME, null, VALID_IS_COMPLETED);
+                VALID_START_TIME, null, VALID_IS_COMPLETED, VALID_IS_PENDING_STATUS);
         assertThrows(IllegalValueException.class, appointment::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -19,6 +20,7 @@ import seedu.address.logic.commands.DeleteAppointmentCommand;
 import seedu.address.logic.commands.DeleteLinkCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.LinkCommand;
+import seedu.address.logic.commands.UpdateAppointmentStatusCommand;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Role;
@@ -98,5 +100,10 @@ public class PersonUtil {
     public static String getDeleteAppointmentCommand(Nric testperson, String date, String time) {
         return DeleteAppointmentCommand.COMMAND_WORD + " " + PREFIX_NRIC + testperson.value
             + " " + PREFIX_DATE + date + " " + PREFIX_START_TIME + time;
+    }
+
+    public static String getUpdateAppointmentStatusCommand(Nric testperson, String date, String time, String status) {
+        return UpdateAppointmentStatusCommand.COMMAND_WORD + " " + PREFIX_NRIC + testperson.value
+            + " " + PREFIX_DATE + date + " " + PREFIX_START_TIME + time + " " + PREFIX_STATUS + status;
     }
 }


### PR DESCRIPTION
**Description:**

This PR introduces the update appointment status feature, which allows users to update the status of an existing appointment. The feature includes the following changes:

* Added a new `UpdateAppointmentStatusCommand` class that handles the update appointment status logic.
* Modified the `Model` interface to include an `updateAppointmentStatus` method.
* Updated the `AppointmentManager` class to include an `updateAppointmentStatus` method that updates the status of an appointment.
* Added a new Status enum
* Added unit tests for the `UpdateAppointmentStatusCommand` class.
* Added `UpdateAppointmentStatusParser` class and its tests as well.
* Modified the Appointment class and json to include status.
* Currently the status can be COMPLETED or PENDING

**Related Issue:**

Fixes #169 